### PR TITLE
Let VDP sleep when there is no data on serial link

### DIFF
--- a/src/VDP.rs
+++ b/src/VDP.rs
@@ -762,7 +762,10 @@ impl VDP<'_> {
                     }
                 }
             },
-            Err(_e) => ()
+            Err(TryRecvError::Empty) => {
+                std::thread::sleep(std::time::Duration::from_millis(1));
+            }
+            Err(TryRecvError::Disconnected) => ()
         }
     }
 


### PR DESCRIPTION
Greatly reduces CPU load